### PR TITLE
chore(qbx-skillbar/fxmanifest): remove undeclared font file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,8 +11,7 @@ client_script 'client/main.lua'
 files {
     'html/index.html',
     'html/script.js',
-    'html/style.css',
-    'html/VerdanaBold.ttf'
+    'html/style.css'
 }
 
 dependencies {


### PR DESCRIPTION
## Description

![image](https://github.com/Qbox-project/qbx-skillbar/assets/46171436/263f5e73-b1cf-4cf1-95c0-de9685ff2979)

This PR resolves the issue of an undeclared file being indexed from the fxmanifest.

On a side note - the only instance in which qbx-skillbar is referenced is once time in qbx-houses. Do you think we should keep this repo? I could see it being a helpful util class. but maybe not include it in the txAdmin recipe.

Here is my evidence for that note:
![image](https://github.com/Qbox-project/qbx-skillbar/assets/46171436/d3f4dccc-0653-4861-9d85-7d828292d59f)
![image](https://github.com/Qbox-project/qbx-skillbar/assets/46171436/e6c45a27-cc50-4b50-8736-0c50394c694b)

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
